### PR TITLE
Add spreadsheet import endpoint

### DIFF
--- a/apps/job/services/quote_import_service.py
+++ b/apps/job/services/quote_import_service.py
@@ -1,0 +1,156 @@
+"""Services for importing quote spreadsheets."""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import IO, Tuple
+
+import pandas as pd
+from django.db import transaction
+from django.shortcuts import get_object_or_404
+
+from apps.job.models import (
+    AdjustmentEntry,
+    Job,
+    JobPart,
+    JobPricing,
+    MaterialEntry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+REQUIRED_COLUMNS = [
+    "Description",
+    "quantity",
+    "thickness",
+    "Materials",
+    "Labour /laser (inhouse)",
+    "fold cost",
+    "fold set up fee",
+    "hole costs",
+    "welding cost",
+    "Materials cost",
+    "Tube (RHS/SHS/pipe)",
+    "Prep (detail/finish)",
+    "CLEAR",
+]
+
+
+def _validate_columns(df: pd.DataFrame) -> None:
+    """Ensure all required columns exist."""
+
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+
+def _validate_material(thickness: str | float, material: str, materials_df: pd.DataFrame) -> None:
+    """Validate thickness/material combination exists."""
+
+    if materials_df.empty:
+        return
+
+    mask = (materials_df["thickness"] == thickness) & (materials_df["Materials"] == material)
+    if materials_df[mask].empty:
+        raise ValueError(f"Invalid material combination: {thickness} / {material}")
+
+
+@transaction.atomic
+def import_quote_from_excel(
+    job: Job,
+    excel_file: IO[bytes],
+    *,
+    job_pricing_id: str | None = None,
+) -> Tuple[JobPricing, int, Decimal, Decimal]:
+    """Read the Excel spreadsheet and populate JobParts and related entries."""
+
+    # Resolve job pricing
+    if job_pricing_id:
+        job_pricing = get_object_or_404(JobPricing, id=job_pricing_id, job=job)
+    else:
+        job_pricing = JobPricing.objects.create(job=job, pricing_stage="estimate")
+
+    xl = pd.ExcelFile(excel_file, engine="openpyxl")
+
+    try:
+        primary_df = pd.read_excel(xl, sheet_name="Primary Details", engine="openpyxl")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed reading Primary Details sheet: %s", exc)
+        raise ValueError("Unable to read 'Primary Details' sheet") from exc
+
+    _validate_columns(primary_df)
+
+    try:
+        materials_df = pd.read_excel(xl, sheet_name="Materials", engine="openpyxl")
+    except Exception:
+        materials_df = pd.DataFrame()
+
+    parts_created = 0
+    total_material_cost = Decimal("0")
+    total_adjustments_cost = Decimal("0")
+
+    adjustment_columns = [
+        "fold cost",
+        "fold set up fee",
+        "hole costs",
+        "welding cost",
+        "Tube (RHS/SHS/pipe)",
+        "Prep (detail/finish)",
+    ]
+
+    for _, row in primary_df.iterrows():
+        description = str(row.get("Description", "")).strip()
+        if not description:
+            continue
+        clear_flag = str(row.get("CLEAR", "")).strip().upper()
+        if clear_flag == "CLEAR":
+            continue
+
+        quantity = row.get("quantity", 0)
+        if quantity == 0:
+            raise ValueError("Row has quantity of zero")
+
+        _validate_material(row.get("thickness"), row.get("Materials"), materials_df)
+
+        part = JobPart.objects.create(
+            job_pricing=job_pricing,
+            name=description,
+            description=str(row.get("customer notes", "")),
+        )
+
+        qty = Decimal(str(quantity))
+        materials_cost = Decimal(str(row.get("Materials cost", 0)))
+        unit_cost = materials_cost / qty if qty != 0 else Decimal("0")
+
+        MaterialEntry.objects.create(
+            job_pricing=job_pricing,
+            description="Materials",
+            quantity=qty,
+            unit_cost=unit_cost,
+            unit_revenue=unit_cost,
+        )
+
+        total_material_cost += materials_cost
+
+        row_adjustment_total = Decimal("0")
+        for col in adjustment_columns:
+            value = row.get(col)
+            if value and not pd.isna(value):
+                cost_val = Decimal(str(value))
+                AdjustmentEntry.objects.create(
+                    job_pricing=job_pricing,
+                    description=col.lower(),
+                    cost_adjustment=cost_val,
+                    price_adjustment=Decimal("0"),
+                )
+                total_adjustments_cost += cost_val
+                row_adjustment_total += cost_val
+
+        labour_cost = Decimal(str(row.get("Labour /laser (inhouse)", 0)))
+        part.raw_total_cost = materials_cost + row_adjustment_total + labour_cost
+        parts_created += 1
+
+    return job_pricing, parts_created, total_material_cost, total_adjustments_cost
+

--- a/apps/job/static/job/js/quote_import.js
+++ b/apps/job/static/job/js/quote_import.js
@@ -1,0 +1,49 @@
+import { getJobIdFromUrl } from "./job_buttons/button_utils.js";
+import { getCSRFToken } from "./job_file_handling.js";
+import { renderMessages } from "/static/timesheet/js/timesheet_entry/messages.js";
+
+export function initQuoteImport() {
+  const button = document.getElementById("importQuoteButton");
+  const fileInput = document.getElementById("importQuoteFileInput");
+  if (!button || !fileInput) {
+    return;
+  }
+
+  button.addEventListener("click", () => fileInput.click());
+
+  fileInput.addEventListener("change", async () => {
+    const file = fileInput.files[0];
+    if (!file) {
+      return;
+    }
+
+    const jobId = getJobIdFromUrl();
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const response = await fetch(`/jobs/api/jobs/${jobId}/import-quote/`, {
+        method: "POST",
+        headers: {
+          "X-CSRFToken": getCSRFToken(),
+        },
+        body: formData,
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message = data.error || "Failed to import quote";
+        renderMessages([{ level: "danger", message }], "toast-container");
+        return;
+      }
+
+      renderMessages([{ level: "success", message: "Quote imported" }], "toast-container");
+      window.location.reload();
+    } catch (error) {
+      console.error("Import quote error", error);
+      renderMessages([{ level: "danger", message: "Import failed" }], "toast-container");
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initQuoteImport);

--- a/apps/job/templates/jobs/edit_job_ajax.html
+++ b/apps/job/templates/jobs/edit_job_ajax.html
@@ -102,6 +102,10 @@
         <div id="simpleQuoteTotalsTable" class="ag-theme-alpine prince-entry-table totals-table simple-pricing-table"></div>
 
         <div class="d-flex gap-2 mt-3">
+            <button type="button" id="importQuoteButton" class="btn btn-secondary">
+                <i class="bi bi-upload me-2"></i>Import Quote
+            </button>
+            <input type="file" id="importQuoteFileInput" accept=".xlsx,.xls" class="d-none">
             <button id="quoteJobButton" class="btn btn-primary" {% if quoted %} disabled {% endif %}>
                 <i class="bi bi-file-text me-2"></i>Quote Job
             </button>
@@ -306,4 +310,5 @@
 <script type="module" src="{% static 'js/time_conversion.js' %}"></script>
 <script type="module" src="{% static 'job/js/delete_job.js' %}"></script>
 <script type="module" src="{% static 'job/js/quill_init.js' %}"></script>
+<script type="module" src="{% static 'job/js/quote_import.js' %}"></script>
 {% endblock %}

--- a/apps/job/tests/test_import_quote.py
+++ b/apps/job/tests/test_import_quote.py
@@ -1,0 +1,78 @@
+import io
+
+import pandas as pd
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+import django
+
+django.setup()
+
+from apps.job.models import Job
+
+
+@pytest.fixture()
+def job(db):
+    return Job.objects.create(name="Test", charge_out_rate=10)
+
+
+def create_excel(valid=True, quantity=1):
+    primary = pd.DataFrame(
+        [
+            {
+                "Description": "Part A",
+                "quantity": quantity,
+                "thickness": 1.5,
+                "Materials": "SS316",
+                "Labour /laser (inhouse)": 5,
+                "fold cost": 1,
+                "fold set up fee": 1,
+                "hole costs": 2,
+                "welding cost": 3,
+                "Materials cost": 10,
+                "Tube (RHS/SHS/pipe)": 0,
+                "Prep (detail/finish)": 0,
+                "CLEAR": "",
+            }
+        ]
+    )
+
+    if not valid:
+        primary = primary.drop(columns=["fold cost"])
+
+    materials = pd.DataFrame({"thickness": [1.5], "Materials": ["SS316"]})
+
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        primary.to_excel(writer, sheet_name="Primary Details", index=False)
+        materials.to_excel(writer, sheet_name="Materials", index=False)
+    buffer.seek(0)
+    return buffer
+
+
+def test_valid_import(job):
+    client = APIClient()
+    buffer = create_excel()
+    url = reverse("jobs:import_quote", args=[job.id])
+    response = client.post(url, {"file": buffer}, format="multipart")
+    assert response.status_code == 201
+    data = response.json()
+    assert data["parts_created"] == 1
+    assert data["total_material_cost"] == "10"
+
+
+def test_missing_columns(job):
+    client = APIClient()
+    buffer = create_excel(valid=False)
+    url = reverse("jobs:import_quote", args=[job.id])
+    response = client.post(url, {"file": buffer}, format="multipart")
+    assert response.status_code == 400
+
+
+def test_zero_quantity(job):
+    client = APIClient()
+    buffer = create_excel(quantity=0)
+    url = reverse("jobs:import_quote", args=[job.id])
+    response = client.post(url, {"file": buffer}, format="multipart")
+    assert response.status_code == 400
+

--- a/apps/job/urls.py
+++ b/apps/job/urls.py
@@ -19,6 +19,7 @@ from apps.job.views import (
     ArchiveCompleteJobsViews,
     AssignJobView,
     JobFileView,
+    import_quote_view,
 )
 
 app_name = "jobs"
@@ -70,6 +71,11 @@ urlpatterns = [
         "api/job/<uuid:job_id>/assignment",
         AssignJobView.as_view(),
         name="api_job_assigment",
+    ),
+    path(
+        "api/jobs/<uuid:job_id>/import-quote/",
+        import_quote_view.ImportQuoteView.as_view(),
+        name="import_quote",
     ),
     path(
         "api/job-event/<uuid:job_id>/add-event/",

--- a/apps/job/views/__init__.py
+++ b/apps/job/views/__init__.py
@@ -8,6 +8,7 @@ from .archive_completed_jobs_view import (
 from .assign_job_view import AssignJobView
 from .job_file_upload import JobFileUploadView
 from .job_file_view import BinaryFileRenderer, JobFileView
+from .import_quote_view import ImportQuoteView
 from .workshop_view import WorkshopPDFView
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "BinaryFileRenderer",
     "JobFileView",
     "WorkshopPDFView",
+    "ImportQuoteView",
 ]

--- a/apps/job/views/import_quote_view.py
+++ b/apps/job/views/import_quote_view.py
@@ -1,0 +1,57 @@
+"""API endpoint to import quote spreadsheets.
+
+Example usage with ``curl``::
+
+    curl -X POST -F "file=@quote.xlsx" \
+         http://localhost:8000/jobs/api/jobs/<job_id>/import-quote/
+
+This will create ``JobPart`` and related entries from the spreadsheet.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from django.shortcuts import get_object_or_404
+
+from apps.job.models import Job
+from apps.job.services.quote_import_service import import_quote_from_excel
+
+logger = logging.getLogger(__name__)
+
+
+class ImportQuoteView(APIView):
+    """Handle spreadsheet uploads and create pricing entries."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, job_id, *args, **kwargs):
+        job = get_object_or_404(Job, id=job_id)
+
+        file = request.FILES.get("file")
+        if not file:
+            return Response({"error": "File is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        job_pricing_id = request.data.get("job_pricing_id")
+
+        try:
+            job_pricing, parts_created, material_cost, adjustment_cost = import_quote_from_excel(
+                job, file, job_pricing_id=job_pricing_id
+            )
+        except ValueError as exc:  # noqa: BLE001
+            logger.error("Import error: %s", exc)
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        data = {
+            "job_pricing_id": str(job_pricing.id),
+            "parts_created": parts_created,
+            "total_material_cost": str(material_cost),
+            "total_adjustments_cost": str(adjustment_cost),
+        }
+        return Response(data, status=status.HTTP_201_CREATED)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ isort = "^5.13.2"
 vulture = "^2.12"
 deptry = "^0.20.0"
 pandas = "^2.2.3"
+openpyxl = "^3.1.2"
 django-debug-toolbar = "^4.4.6"
 pylint-django = "^2.6.1"
 


### PR DESCRIPTION
## Summary
- add pandas-based quote import service
- expose new API endpoint to upload Excel quote sheets
- register URL and include example usage
- add tests for quote import
- include openpyxl dependency

## Testing
- `pytest -q` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_6845aea3fbbc8331a3f4a2e3b58111c3