### PR TITLE
Add month-end REST API

### DIFF
--- a/apps/accounts/views/token_view.py
+++ b/apps/accounts/views/token_view.py
@@ -1,4 +1,5 @@
 import logging
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -10,6 +11,7 @@ from apps.accounts.serializers import CustomTokenObtainPairSerializer
 
 logger = logging.getLogger(__name__)
 
+
 class CustomTokenObtainPairView(TokenObtainPairView):
     """
     Customized token obtain view that handles password reset requirement
@@ -19,7 +21,10 @@ class CustomTokenObtainPairView(TokenObtainPairView):
     serializer_class = CustomTokenObtainPairSerializer
 
     def post(self, request, *args, **kwargs):
-        logger.info("CustomTokenObtainPairView POST called with username: %s", request.data.get("username"))
+        logger.info(
+            "CustomTokenObtainPairView POST called with username: %s",
+            request.data.get("username"),
+        )
         response = super().post(request, *args, **kwargs)
 
         if response.status_code == status.HTTP_200_OK:
@@ -51,7 +56,9 @@ class CustomTokenObtainPairView(TokenObtainPairView):
                 logger.warning("User %s does not exist", username)
 
         else:
-            logger.warning("Token obtain failed with status code: %s", response.status_code)
+            logger.warning(
+                "Token obtain failed with status code: %s", response.status_code
+            )
 
         return response
 

--- a/apps/job/services/month_end_service.py
+++ b/apps/job/services/month_end_service.py
@@ -1,0 +1,103 @@
+import logging
+from decimal import Decimal
+from typing import List, Tuple
+
+from django.db import transaction
+from django.shortcuts import get_object_or_404
+
+from apps.job.models import CostSet, Job
+from apps.purchasing.models import Stock
+
+logger = logging.getLogger(__name__)
+
+
+class MonthEndService:
+    @staticmethod
+    def _get_stock_job() -> Job:
+        return Stock.get_stock_holding_job()
+
+    @staticmethod
+    def get_special_jobs() -> List[Job]:
+        stock_job = MonthEndService._get_stock_job()
+        return list(Job.objects.filter(status="special").exclude(id=stock_job.id))
+
+    @staticmethod
+    def _build_job_history(job: Job) -> List[dict]:
+        history = []
+        for cs in (
+            job.cost_sets.filter(kind="actual")
+            .exclude(id=job.latest_actual_id)
+            .order_by("created")
+        ):
+            history.append(
+                {
+                    "date": cs.created,
+                    "total_hours": Decimal(str(cs.summary.get("hours", 0))),
+                    "total_dollars": Decimal(str(cs.summary.get("cost", 0))),
+                }
+            )
+        return history
+
+    @staticmethod
+    def get_special_jobs_data() -> List[dict]:
+        data = []
+        for job in MonthEndService.get_special_jobs():
+            actual = job.latest_actual
+            data.append(
+                {
+                    "job": job,
+                    "history": MonthEndService._build_job_history(job),
+                    "total_hours": (
+                        Decimal(str(actual.summary.get("hours", 0)))
+                        if actual
+                        else Decimal("0")
+                    ),
+                    "total_dollars": (
+                        Decimal(str(actual.summary.get("cost", 0)))
+                        if actual
+                        else Decimal("0")
+                    ),
+                }
+            )
+        return data
+
+    @staticmethod
+    def get_stock_job_data() -> dict:
+        job = MonthEndService._get_stock_job()
+        history = []
+        for cs in job.cost_sets.filter(kind="actual").order_by("created"):
+            material_lines = cs.cost_lines.filter(kind="material")
+            total_cost = sum(
+                (line.total_cost for line in material_lines),
+                Decimal("0"),
+            )
+            history.append(
+                {
+                    "date": cs.created,
+                    "material_line_count": material_lines.count(),
+                    "material_cost": total_cost,
+                }
+            )
+        return {"job": job, "history": history}
+
+    @staticmethod
+    def process_jobs(job_ids: List[str]) -> Tuple[List[Job], List[Tuple[str, str]]]:
+        processed_jobs: List[Job] = []
+        error_jobs: List[Tuple[str, str]] = []
+        for job_id in job_ids:
+            try:
+                job = get_object_or_404(Job, id=job_id)
+                with transaction.atomic():
+                    rev = job.cost_sets.filter(kind="actual").count() + 1
+                    new_set = CostSet.objects.create(
+                        job=job,
+                        kind="actual",
+                        rev=rev,
+                        summary={"cost": 0, "rev": 0, "hours": 0},
+                    )
+                    job.set_latest("actual", new_set)
+                processed_jobs.append(job)
+            except Exception as e:
+                logger.exception("Error processing job %s", job_id)
+                error_jobs.append((job_id, str(e)))
+        return processed_jobs, error_jobs

--- a/apps/job/urls_rest.py
+++ b/apps/job/urls_rest.py
@@ -35,6 +35,7 @@ from apps.job.views.modern_timesheet_views import (
     ModernTimesheetEntryView,
     ModernTimesheetJobView,
 )
+from apps.job.views.month_end_rest_view import MonthEndRestView
 from apps.job.views.quote_import_views import QuoteImportStatusView
 from apps.job.views.quote_sync_views import apply_quote, link_quote_sheet, preview_quote
 from apps.job.views.workshop_view import WorkshopPDFView
@@ -43,6 +44,7 @@ from apps.job.views.workshop_view import WorkshopPDFView
 rest_urlpatterns = [
     # Job CRUD operations (REST style)
     path("rest/jobs/", JobCreateRestView.as_view(), name="job_create_rest"),
+    path("rest/month-end/", MonthEndRestView.as_view(), name="month_end_rest"),
     path(
         "rest/jobs/<uuid:job_id>/", JobDetailRestView.as_view(), name="job_detail_rest"
     ),

--- a/apps/job/views/month_end_rest_view.py
+++ b/apps/job/views/month_end_rest_view.py
@@ -1,0 +1,77 @@
+import json
+import logging
+from typing import Any, Dict
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.job.services.month_end_service import MonthEndService
+
+logger = logging.getLogger(__name__)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class MonthEndRestView(APIView):
+    def get(self, request):
+        jobs = MonthEndService.get_special_jobs_data()
+        stock = MonthEndService.get_stock_job_data()
+        serialized_jobs = [
+            {
+                "job_id": str(item["job"].id),
+                "job_number": item["job"].job_number,
+                "job_name": item["job"].name,
+                "client_name": item["job"].client.name if item["job"].client else "",
+                "history": [
+                    {
+                        "date": h["date"],
+                        "total_hours": float(h["total_hours"]),
+                        "total_dollars": float(h["total_dollars"]),
+                    }
+                    for h in item["history"]
+                ],
+                "total_hours": float(item["total_hours"]),
+                "total_dollars": float(item["total_dollars"]),
+            }
+            for item in jobs
+        ]
+        stock_serialized = {
+            "job_id": str(stock["job"].id),
+            "job_number": stock["job"].job_number,
+            "job_name": stock["job"].name,
+            "history": [
+                {
+                    "date": h["date"],
+                    "material_line_count": h["material_line_count"],
+                    "material_cost": float(h["material_cost"]),
+                }
+                for h in stock["history"]
+            ],
+        }
+        return Response(
+            {"jobs": serialized_jobs, "stock_job": stock_serialized},
+            status=status.HTTP_200_OK,
+        )
+
+    def post(self, request):
+        try:
+            payload: Dict[str, Any] = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return Response(
+                {"error": "Invalid JSON"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        job_ids = payload.get("job_ids", [])
+        if not isinstance(job_ids, list):
+            return Response(
+                {"error": "job_ids must be a list"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        processed, errors = MonthEndService.process_jobs(job_ids)
+        return Response(
+            {
+                "processed": [str(job.id) for job in processed],
+                "errors": errors,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/docs/api/month_end_api.md
+++ b/docs/api/month_end_api.md
@@ -1,0 +1,51 @@
+# Month-End API Guide
+
+## Endpoints
+
+### `GET /rest/month-end/`
+Returns a JSON object with two keys:
+
+- `jobs`: list of special jobs excluding the stock job
+- `stock_job`: data about the stock job
+
+Each job entry includes:
+
+```
+{
+  "job_id": "UUID",
+  "job_number": 123,
+  "job_name": "name",
+  "client_name": "client",
+  "history": [
+    {"date": "ISO", "total_hours": 0.0, "total_dollars": 0.0}
+  ],
+  "total_hours": 0.0,
+  "total_dollars": 0.0
+}
+```
+
+`stock_job` contains:
+
+```
+{
+  "job_id": "UUID",
+  "job_number": 1,
+  "job_name": "Worker Admin",
+  "history": [
+    {"date": "ISO", "material_line_count": 0, "material_cost": 0.0}
+  ]
+}
+```
+
+### `POST /rest/month-end/`
+Send a JSON body with job IDs to run month end:
+
+```
+{"job_ids": ["uuid1", "uuid2"]}
+```
+
+Response lists processed jobs and any errors:
+
+```
+{"processed": ["uuid1"], "errors": [["uuid2", "error message"]]}
+```


### PR DESCRIPTION
## Summary
- create `MonthEndService` and implement actual cost set reset logic
- expose REST view `MonthEndRestView`
- wire new endpoint in `urls_rest`
- format `token_view` to satisfy linting

## Testing
- `tox -e lint`
- `tox -e typecheck` *(fails: Function is missing a type annotation)*
- `tox -e mypy` *(failed due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a4e95d88331ab0a85437ff4cb76